### PR TITLE
Fix requirements order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.14.0
 bleach==2.1.2
 cycler==0.10.0
 decorator==4.2.1
@@ -22,7 +23,6 @@ nbconvert==5.3.1
 nbformat==4.4.0
 networkx==2.0
 notebook==5.3.1
-numpy==1.14.0
 pandas==0.22.0
 pandocfilters==1.4.2
 parso==0.1.1


### PR DESCRIPTION
There is an error when installing the requirements in a virtual environment because libtiff depends on numpy so we need it to be installed before libtiff. The error shows up like this

```
Collecting libtiff==0.4.2 (from -r requirements.txt (line 17))
  Downloading libtiff-0.4.2.tar.gz (129kB)
    100% |████████████████████████████████| 133kB 2.3MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-z1mld02v/libtiff/setup.py", line 77, in <module>
        from numpy.distutils.core import setup, Extension
    ImportError: No module named 'numpy'
```

Other errors may occur following the wiki instructions, you should not run `jupyter` like this, but prefixing with `python -m` to use `python` from the virtual environment:

```bash
python -m jupyter nbextension enable --py widgetsnbextension
python -m jupyter notebook
```